### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kcharselect.json
+++ b/org.kde.kcharselect.json
@@ -12,7 +12,7 @@
         "--socket=wayland"
     ],
     "cleanup": [
-        "/share/app-info"
+        "/share/doc"
     ],
     "modules": [
         {


### PR DESCRIPTION
The installed size reduced from 689,7 kB to 250,9 kB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.